### PR TITLE
Gewichtung korrekt ändern

### DIFF
--- a/Calq/Screens/SettingsScreen/EditWeightScreen.swift
+++ b/Calq/Screens/SettingsScreen/EditWeightScreen.swift
@@ -44,11 +44,7 @@ struct ChangeWeightScreen: View {
             .navigationTitle("Wertung ändern")
             .toolbar{Image(systemName: "xmark").onTapGesture{dismissSheet()}}
             .onAppear{
-                stepperValue = Int(Double(Util.getSettings()!.weightBigGrades)! * 10)
-                
-                if stepperValue % 10 != 0 {
-                    stepperValue = 50;
-                }
+                stepperValue = Int(Double(Util.getSettings()!.weightBigGrades)! * 100)
             }
     }
     

--- a/Calq/Screens/SettingsScreen/EditWeightScreen.swift
+++ b/Calq/Screens/SettingsScreen/EditWeightScreen.swift
@@ -45,6 +45,10 @@ struct ChangeWeightScreen: View {
             .toolbar{Image(systemName: "xmark").onTapGesture{dismissSheet()}}
             .onAppear{
                 stepperValue = Int(Double(Util.getSettings()!.weightBigGrades)! * 10)
+                
+                if stepperValue % 10 != 0 {
+                    stepperValue = 50;
+                }
             }
     }
     

--- a/Calq/lib/Util.swift
+++ b/Calq/lib/Util.swift
@@ -210,7 +210,7 @@ struct Util {
     
     static func saveWeigth(_ num: Int){
         let settings = getSettings()
-        settings!.weightBigGrades = String(num/100)
+        settings!.weightBigGrades = String(Float(num) / 100)
         saveCoreData()
     }
     


### PR DESCRIPTION
Die Gewichtung zwischen Test / Klausur beträgt immer 0%, da der Integer mit dem Gewicht zwischen 0-100 durch 100 geteilt wird. Da die Rechnung im Integer-Bereich stattfindet wird immer auf 0 gerundet. Um das Problem zu beheben muss der Integer zum Float / Double konvertiert werden. https://github.com/AKORA-Studios/Calq/blob/15f7833246c00c48c04f417ef98cf47cea96234e/Calq/lib/Util.swift#L213

Durch eine Änderung an der Bearbeitungsszene habe ich sichergestellt das der Prozentsatz immer ein vielfaches von zehn ist, da dies nach der Änderung nicht mehr der Fall war.